### PR TITLE
Update CueSheet.Deserializer.cs

### DIFF
--- a/Files/CueSheet.Deserializer.cs
+++ b/Files/CueSheet.Deserializer.cs
@@ -165,11 +165,16 @@ namespace SabreTools.Serialization.Files
                         cueTracks.Add(track);
                         break;
 
-                    // Default means return
-                    default:
+                    // Next file found, return
+                    case "FILE":
                         i--;
                         cueFile.Tracks = cueTracks.ToArray();
                         return cueFile;
+
+                    // Default means return
+                    default:
+                        i--;
+                        return null;
                 }
             }
 
@@ -300,11 +305,17 @@ namespace SabreTools.Serialization.Files
                         cueTrack.PostGap = postgap;
                         break;
 
-                    // Default means return
-                    default:
+                    // Next track or file found, return
+                    case "TRACK":
+                    case "FILE":
                         i--;
                         cueTrack.Indices = cueIndices.ToArray();
                         return cueTrack;
+                    
+                    // Default means return
+                    default:
+                        i--;
+                        return null;
                 }
             }
 

--- a/Files/CueSheet.Deserializer.cs
+++ b/Files/CueSheet.Deserializer.cs
@@ -168,7 +168,8 @@ namespace SabreTools.Serialization.Files
                     // Default means return
                     default:
                         i--;
-                        return null;
+                        cueFile.Tracks = cueTracks.ToArray();
+                        return cueFile;
                 }
             }
 
@@ -302,7 +303,8 @@ namespace SabreTools.Serialization.Files
                     // Default means return
                     default:
                         i--;
-                        return null;
+                        cueTrack.Indices = cueIndices.ToArray();
+                        return cueTrack;
                 }
             }
 


### PR DESCRIPTION
Don't return null when cuesheet is not ended, instead return the current CUE file/track
This prevents Cuesheet deserializer from returning malformed tracks and files for multi-file CUEs.