### PR TITLE
Add extra validity checks for GCF

### DIFF
--- a/SabreTools.Serialization/Deserializers/GCF.cs
+++ b/SabreTools.Serialization/Deserializers/GCF.cs
@@ -104,7 +104,7 @@ namespace SabreTools.Serialization.Deserializers
 
                 #region Directory Header
 
-                // Try to parse game cache directory header for validity
+                // Try to parse game cache directory header
                 var directoryHeader = ParseDirectoryHeader(data);
                 if (directoryHeader.Dummy0 != 0x00000004)
                     return null;


### PR DESCRIPTION
Fixes false GCF detection on idtech 5 md5 binary model format https://github.com/SabreTools/BinaryObjectScanner/issues/376 . Adds a few extra validity checks mentioned in HLLib, specifically

https://github.com/Rupan/HLLib/blob/47de5d5fed1b4d8e160c20f50d0bf61999996161/HLLib/GCFFile.h#L104
https://github.com/Rupan/HLLib/blob/47de5d5fed1b4d8e160c20f50d0bf61999996161/HLLib/GCFFile.h#L109

which should avoid any other false positives from Enemy Territory's md5b files.