### PR TITLE
Temporary fix for solid archive detection until SharpCompress makes another release.

### DIFF
--- a/SabreTools.Serialization/Wrappers/RAR.Extraction.cs
+++ b/SabreTools.Serialization/Wrappers/RAR.Extraction.cs
@@ -48,8 +48,46 @@ namespace SabreTools.Serialization.Wrappers
                     else if (rarFile.Entries.Count == 0)
                         rarFile = RarArchive.Open(parts, readerOptions);
                 }
+                
+                // Explained in https://github.com/adamhathcock/sharpcompress/pull/661. in order to determine whether  
+                // a RAR or 7Z archive is solid or not, you must check the second file in the archive, as the first 
+                // file is always marked non-solid even for solid archives. This iteration is necessary since things
+                // like directories aren't marked solid either.
+                // This is only temporary, as solid detection has been fixed in upstream SolidCompress, but they likely
+                // won't make a new release for a while, and this is too big an issue to leave unfixed.
+                bool firstFile = true;
+                bool isSolid = false;
+                foreach (var entry in rarFile.Entries)
+                {
+                    try
+                    {
+                        // If the entry is a directory
+                        if (entry.IsDirectory)
+                            continue;
 
-                if (rarFile.IsSolid)
+                        // If the entry has an invalid key
+                        if (entry.Key == null)
+                            continue;
+
+                        // If we have a partial entry due to an incomplete multi-part archive, skip it
+                        if (!entry.IsComplete)
+                            continue;
+
+                        if (firstFile)
+                            firstFile = false;
+                        else
+                        {
+                            isSolid = entry.IsSolid;
+                            break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        if (includeDebug) Console.WriteLine(ex);
+                    }
+                }
+
+                if (isSolid)
                     return ExtractSolid(rarFile, outputDirectory, includeDebug);
                 else
                     return ExtractNonSolid(rarFile, outputDirectory, includeDebug);

--- a/SabreTools.Serialization/Wrappers/SevenZip.Extraction.cs
+++ b/SabreTools.Serialization/Wrappers/SevenZip.Extraction.cs
@@ -48,9 +48,45 @@ namespace SabreTools.Serialization.Wrappers
                         sevenZip = SevenZipArchive.Open(parts, readerOptions);
                 }
 
-                // Currently doesn't flag solid 7z archives with only 1 solid block as solid, but practically speaking
-                // this is not much of a concern.
-                if (sevenZip.IsSolid)
+                // Explained in https://github.com/adamhathcock/sharpcompress/pull/661. in order to determine whether  
+                // a RAR or 7Z archive is solid or not, you must check the second file in the archive, as the first 
+                // file is always marked non-solid even for solid archives. This iteration is necessary since things
+                // like directories aren't marked solid either.
+                // This is only temporary, as solid detection has been fixed in upstream SolidCompress, but they likely
+                // won't make a new release for a while, and this is too big an issue to leave unfixed.
+                bool firstFile = true;
+                bool isSolid = false;
+                foreach (var entry in sevenZip.Entries)
+                {
+                    try
+                    {
+                        // If the entry is a directory
+                        if (entry.IsDirectory)
+                            continue;
+
+                        // If the entry has an invalid key
+                        if (entry.Key == null)
+                            continue;
+
+                        // If we have a partial entry due to an incomplete multi-part archive, skip it
+                        if (!entry.IsComplete)
+                            continue;
+
+                        if (firstFile)
+                            firstFile = false;
+                        else
+                        {
+                            isSolid = entry.IsSolid;
+                            break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        if (includeDebug) Console.WriteLine(ex);
+                    }
+                }
+                
+                if (isSolid)
                     return ExtractSolid(sevenZip, outputDirectory, includeDebug);
                 else
                     return ExtractNonSolid(sevenZip, outputDirectory, includeDebug);


### PR DESCRIPTION
At present, the release of SharpCompress that Serialization uses is missing the fix for single-block solid archive detection that was pushed a month or so afterwards https://github.com/adamhathcock/sharpcompress/pull/924 . From my own observations, and the experiences of various MPF/BOS users, solid archives (especially solid 7Z archives) tend to only be one block, so this winds up being a pretty major issue, resulting in extraction more or less locking up anytime a 7z is encountered. I understand that this fix isn't the most elegant, but it doesn't actually waste that much time since it only needs to check for two file entries, and it will have a major positive impact on processing times, given the state of solid extraction without it is borderline unusable on large archives with many files.
This backports what I had done for the original commit https://github.com/SabreTools/BinaryObjectScanner/pull/375/commits/ecd99b157db50c34cd0c91fa36ffde9f9c9b10e3 in the pull where this was first found https://github.com/SabreTools/BinaryObjectScanner/pull/375 .