### PR TITLE
Small fix to temp solid code just in case

### DIFF
--- a/SabreTools.Serialization/Wrappers/RAR.Extraction.cs
+++ b/SabreTools.Serialization/Wrappers/RAR.Extraction.cs
@@ -87,7 +87,10 @@ namespace SabreTools.Serialization.Wrappers
                     }
                 }
 
-                if (isSolid)
+                // Still check SharpCompress's archive-level isSolid flag. Based on the way the check works on their
+                // end, it's possible that a multi-block solid archive might have the second (or more files) file not
+                // solid? It doesn't hurt to check either way.
+                if (isSolid || rarFile.IsSolid)
                     return ExtractSolid(rarFile, outputDirectory, includeDebug);
                 else
                     return ExtractNonSolid(rarFile, outputDirectory, includeDebug);

--- a/SabreTools.Serialization/Wrappers/SevenZip.Extraction.cs
+++ b/SabreTools.Serialization/Wrappers/SevenZip.Extraction.cs
@@ -86,7 +86,10 @@ namespace SabreTools.Serialization.Wrappers
                     }
                 }
                 
-                if (isSolid)
+                // Still check SharpCompress's archive-level isSolid flag. Based on the way the check works on their
+                // end, it's possible that a multi-block solid archive might have the second (or more files) file not
+                // solid? It doesn't hurt to check either way.
+                if (isSolid || sevenZip.IsSolid)
                     return ExtractSolid(sevenZip, outputDirectory, includeDebug);
                 else
                     return ExtractNonSolid(sevenZip, outputDirectory, includeDebug);


### PR DESCRIPTION
Based on the way SharpCompress's check works on their end, it's possible that a multi-block solid archive might have the second (or more files) file not solid? It doesn't hurt to check either way.