### PR TITLE
increase buffer size for isexe reading / writing based on deterous's …

### DIFF
--- a/SabreTools.Serialization/Wrappers/PortableExecutable.Extraction.cs
+++ b/SabreTools.Serialization/Wrappers/PortableExecutable.Extraction.cs
@@ -176,7 +176,7 @@ namespace SabreTools.Serialization.Wrappers
                 if (overlayAddress < 0)
                     return false;
 
-                const int chunkSize = 2048 * 1024; //Arbitrary buffer size
+                const int chunkSize = 2048 * 1024;
                 var reader = new Readers.InstallShieldExecutableFile();
 
                 lock (_dataSourceLock)


### PR DESCRIPTION
The buffer size is fully arbitrary, and I had only chosen what it currently is just based on a whim. According to deterous, this buffer size has worked best for him and others in various environments, and overall I trust it much more than my previous tiny buffer size.