### PR TITLE
ISO9660: Skip interleaved files and other fixes

### DIFF
--- a/SabreTools.Serialization/Wrappers/ISO9660.Extraction.cs
+++ b/SabreTools.Serialization/Wrappers/ISO9660.Extraction.cs
@@ -10,6 +10,21 @@ namespace SabreTools.Serialization.Wrappers
 {
     public partial class ISO9660 : IExtractable
     {
+        #region Extraction State
+
+        /// <summary>
+        /// List of extracted files by their sector offset
+        /// </summary>
+        private Dictionary<int, int> extractedFiles = [];
+
+        /// <summary>
+        /// List of multi-extent files written, by their FileIdentifier
+        /// </summary>
+        /// <remarks>Used as last-extent has mutli-extent flag=0</remarks>
+        private List<byte[]> multiExtentFiles = [];
+
+        #endregion
+
         /// <inheritdoc/>
         public virtual bool Extract(string outputDirectory, bool includeDebug)
         {

--- a/SabreTools.Serialization/Wrappers/ISO9660.cs
+++ b/SabreTools.Serialization/Wrappers/ISO9660.cs
@@ -29,14 +29,6 @@ namespace SabreTools.Serialization.Wrappers
 
         #endregion
 
-        #region Global Variables
-
-        private Dictionary<int, int> extractedFiles = new Dictionary<int, int>();
-
-        private List<byte[]> multiExtentFiles = new List<byte[]>();
-
-        #endregion
-
         #region Constructors
 
         /// <inheritdoc/>


### PR DESCRIPTION
- Don't attempt to extract interleaved files
- Fix directory key value in dictionary
- Prevent overflow when seeking