### PR TITLE
Fix extraction of recent MPF-zipped logs

### DIFF
--- a/SabreTools.Serialization/Readers/PKZIP.cs
+++ b/SabreTools.Serialization/Readers/PKZIP.cs
@@ -770,7 +770,7 @@ namespace SabreTools.Serialization.Readers
 
             obj.HeaderID = (HeaderID)data.ReadUInt16LittleEndian(ref offset);
             obj.DataSize = data.ReadUInt16LittleEndian(ref offset);
-            if (obj.DataSize <= 0)            
+            if (obj.DataSize > 0)            
                 obj.Data = data.ReadBytes(ref offset, obj.DataSize);
 
             return obj;


### PR DESCRIPTION
At least with recent zstd compressed zip logs, ST would attempt to use IO's byte array extensions' ReadBytes method with a count of 0 bytes, which obviously throws an exception. By gating this line behind datasize not being zero, ST successfully extracts all files.

Example affected zip:
[DISK1_logs.zip](https://github.com/user-attachments/files/23289298/DISK1_logs.zip)
