### PR TITLE
Explicitly handle password-protected archives rather than repeatedly throwing exceptions

### DIFF
--- a/SabreTools.Serialization/Wrappers/PKZIP.Extraction.cs
+++ b/SabreTools.Serialization/Wrappers/PKZIP.Extraction.cs
@@ -43,7 +43,6 @@ namespace SabreTools.Serialization.Wrappers
                         zipFile = ZipArchive.Open(parts, readerOptions);
                 }
 
-                bool encrypted = false;
                 foreach (var entry in zipFile.Entries)
                 {
                     try
@@ -63,11 +62,7 @@ namespace SabreTools.Serialization.Wrappers
                         // If the entry is password-protected, skip it
                         if (entry.IsEncrypted)
                         {
-                            if (!encrypted)
-                            {
-                                if (includeDebug) Console.WriteLine("Some or all files in zip are password-protected!");
-                                encrypted = true;
-                            }
+                            if (includeDebug) Console.WriteLine($"File {entry.Key} in zip is password-protected!");
                             
                             continue;
                         }

--- a/SabreTools.Serialization/Wrappers/RAR.Extraction.cs
+++ b/SabreTools.Serialization/Wrappers/RAR.Extraction.cs
@@ -213,7 +213,6 @@ namespace SabreTools.Serialization.Wrappers
         /// </summary>
         private static bool ExtractNonSolid(RarArchive rarFile, string outDir, bool includeDebug)
         {
-            bool encrypted = false;
             foreach (var entry in rarFile.Entries)
             {
                 try
@@ -233,11 +232,7 @@ namespace SabreTools.Serialization.Wrappers
                     // If the entry is password-protected, skip it
                     if (entry.IsEncrypted)
                     {
-                        if (!encrypted)
-                        {
-                            if (includeDebug) Console.WriteLine("Some or all files in RAR are password-protected!");
-                            encrypted = true;
-                        }
+                        if (includeDebug) Console.WriteLine($"File {entry.Key} in RAR is password-protected!");
                         
                         continue;
                     }

--- a/SabreTools.Serialization/Wrappers/SevenZip.Extraction.cs
+++ b/SabreTools.Serialization/Wrappers/SevenZip.Extraction.cs
@@ -181,7 +181,6 @@ namespace SabreTools.Serialization.Wrappers
         /// </summary>
         private static bool ExtractNonSolid(SevenZipArchive sevenZip, string outputDirectory, bool includeDebug)
         {
-            bool encrypted = false;
             foreach (var entry in sevenZip.Entries)
             {
                 try
@@ -201,11 +200,7 @@ namespace SabreTools.Serialization.Wrappers
                     // If the entry is password-protected, skip it
                     if (entry.IsEncrypted)
                     {
-                        if (!encrypted)
-                        {
-                            if (includeDebug) Console.WriteLine("Some or all files in 7z are password-protected!");
-                            encrypted = true;
-                        }
+                        if (includeDebug) Console.WriteLine($"File {entry.Key} in 7z is password-protected!");
                         
                         continue;
                     }


### PR DESCRIPTION
At the moment, if running with debug enabled, if you attempt to use ExtractionTool (or BOS) on password-protected archives, it will repeatedly throw exceptions. This PR explicitly handles password-protected files/archives, both providing more accurate output (7z and rar would otherwise not output the actual issue at all) and also making the debug logs much cleaner.