### PR TITLE
Fix GCF extraction

### DIFF
--- a/SabreTools.Serialization/Readers/GCF.cs
+++ b/SabreTools.Serialization/Readers/GCF.cs
@@ -304,7 +304,7 @@ namespace SabreTools.Serialization.Readers
                 #endregion
 
                 // Seek to end of checksum section, just in case
-                data.SeekIfPossible(afterMapPosition + checksumHeader.ChecksumSize, SeekOrigin.Begin);
+                data.SeekIfPossible(initialOffset + checksumHeader.ChecksumSize, SeekOrigin.Begin);
 
                 #region Data Block Header
 


### PR DESCRIPTION
GCF extraction was broken with the big initialOffset change, commit https://github.com/SabreTools/SabreTools.Serialization/commit/cd7e6ff98d4f146e0674e8632c01ff761f95b61e#diff-6cb108a7e2e3e65bf9d0a75be0f79619f0aff47f2a96a9828dd6f67d288057af

GCF extraction previously read `afterMapPosition = data.Position` several times throughout the deserialization, to seek back to at relevant points. This commit changed some, but not all instances of afterMapPosition to initialOffset, resulting in a situation where the final offset reading went unused, and DataBlockHeader was being read from the previous offset.

Mainly detailing this since there's still a remaining inconsistency in usage of afterMapPosition vs initialOffset in the file, and initialOffset seems strange to use after, well, the initial offset.