### PR TITLE
Fix GCF naming convention to avoid future code breakage

### DIFF
--- a/SabreTools.Serialization/Readers/GCF.cs
+++ b/SabreTools.Serialization/Readers/GCF.cs
@@ -261,7 +261,7 @@ namespace SabreTools.Serialization.Readers
                 #endregion
 
                 // Cache the current offset
-                initialOffset = data.Position;
+                long afterChecksumPosition = data.Position;
 
                 #region Checksum Map Header
 
@@ -304,7 +304,7 @@ namespace SabreTools.Serialization.Readers
                 #endregion
 
                 // Seek to end of checksum section, just in case
-                data.SeekIfPossible(initialOffset + checksumHeader.ChecksumSize, SeekOrigin.Begin);
+                data.SeekIfPossible(afterChecksumPosition + checksumHeader.ChecksumSize, SeekOrigin.Begin);
 
                 #region Data Block Header
 


### PR DESCRIPTION
Incorrect/unclear variable naming was the cause of the existing breakage, so this should help avoid future issues