### PR TITLE
Peek in XDVDFS, Support XB00104M

### DIFF
--- a/SabreTools.Data.Models/XboxISO/Constants.cs
+++ b/SabreTools.Data.Models/XboxISO/Constants.cs
@@ -5,15 +5,15 @@ namespace SabreTools.Data.Models.XboxISO
     {
         /// <summary>
         /// Known redump ISO lengths
-        /// 0 = XGD1
-        /// 1/2/3/4 = XGD2
-        /// 5 = XGD2-Hybrid
-        /// 6/7 = XGD3
+        /// 0/1 = XGD1
+        /// 2/3/4/5 = XGD2
+        /// 6 = XGD2-Hybrid
+        /// 7/8 = XGD3
         /// </summary>
         /// <see href="https://github.dev/Deterous/XboxKit/"/>
         public static readonly long[] RedumpIsoLengths = [
-            0x1D26A8000, 0x1D3301800, 0x1D2FEF800, 0x1D3082000,
-            0x1D3390000, 0x1D31A0000, 0x208E05800, 0x208E03800
+            0x1D330C000, 0x1D26A8000, 0x1D3301800, 0x1D2FEF800,
+            0x1D3082000, 0x1D3390000, 0x1D31A0000, 0x208E05800, 0x208E03800
         ];
 
         /// <summary>

--- a/SabreTools.Serialization.Readers/XDVDFS.cs
+++ b/SabreTools.Serialization.Readers/XDVDFS.cs
@@ -67,7 +67,7 @@ namespace SabreTools.Serialization.Readers
         {
             var obj = new VolumeDescriptor();
 
-            temp = data.PeekBytes(20);
+            var temp = data.PeekBytes(20);
             var signature = System.Text.Encoding.ASCII.GetString(temp);
             if (!signature.Equals(Constants.VolumeDescriptorSignature))
                 return null;
@@ -92,7 +92,7 @@ namespace SabreTools.Serialization.Readers
         {
             var obj = new LayoutDescriptor();
 
-            temp = data.PeekBytes(24);
+            var temp = data.PeekBytes(24);
             var signature = System.Text.Encoding.ASCII.GetString(temp);
             if (!signature.Equals(Constants.LayoutDescriptorSignature))
                 return null;

--- a/SabreTools.Serialization.Readers/XDVDFS.cs
+++ b/SabreTools.Serialization.Readers/XDVDFS.cs
@@ -67,11 +67,12 @@ namespace SabreTools.Serialization.Readers
         {
             var obj = new VolumeDescriptor();
 
-            obj.StartSignature = data.ReadBytes(20);
-            var signature = System.Text.Encoding.ASCII.GetString(obj.StartSignature);
+            temp = data.PeekBytes(20);
+            var signature = System.Text.Encoding.ASCII.GetString(temp);
             if (!signature.Equals(Constants.VolumeDescriptorSignature))
                 return null;
 
+            obj.StartSignature = data.ReadBytes(20);
             obj.RootOffset = data.ReadUInt32LittleEndian();
             obj.RootSize = data.ReadUInt32LittleEndian();
             obj.MasteringTimestamp = data.ReadInt64LittleEndian();
@@ -91,19 +92,19 @@ namespace SabreTools.Serialization.Readers
         {
             var obj = new LayoutDescriptor();
 
-            obj.Signature = data.ReadBytes(24);
-            var signature = System.Text.Encoding.ASCII.GetString(obj.Signature);
+            temp = data.PeekBytes(24);
+            var signature = System.Text.Encoding.ASCII.GetString(temp);
             if (!signature.Equals(Constants.LayoutDescriptorSignature))
                 return null;
-            obj.Unused8Bytes = data.ReadBytes(8);
 
+            obj.Signature = data.ReadBytes(24);
+            obj.Unused8Bytes = data.ReadBytes(8);
             obj.XBLayoutVersion = ParseFourPartVersionType(data);
             obj.XBPremasterVersion = ParseFourPartVersionType(data);
             obj.XBGameDiscVersion = ParseFourPartVersionType(data);
             obj.XBOther1Version = ParseFourPartVersionType(data);
             obj.XBOther2Version = ParseFourPartVersionType(data);
             obj.XBOther3Version = ParseFourPartVersionType(data);
-
             obj.Reserved = data.ReadBytes(1968);
 
             return obj;
@@ -160,10 +161,16 @@ namespace SabreTools.Serialization.Readers
                     if (obj.ContainsKey(dr.ExtentOffset))
                         continue;
 
+                // Ensure offset is valid
+                if ((((long)offset) * Constants.SectorSize) + size > data.Length)
+                    return null;
+
                     // Get all descriptors from child
                     var descriptors = ParseDirectoryDescriptors(data, initialOffset, dr.ExtentOffset, dr.ExtentSize);
                     if (descriptors is null)
                         continue;
+
+                    data.SeekIfPossible(initialOffset + (((long)offset) * Constants.SectorSize), SeekOrigin.Begin);
 
                     // Merge dictionaries
                     foreach (var kvp in descriptors)
@@ -190,14 +197,9 @@ namespace SabreTools.Serialization.Readers
             if (size < Constants.MinimumRecordLength)
                 return null;
 
-            // Ensure offset is valid
-            if ((((long)offset) * Constants.SectorSize) + size > data.Length)
-                return null;
-
             var obj = new DirectoryDescriptor();
             var records = new List<DirectoryRecord>();
 
-            data.SeekIfPossible(initialOffset + (((long)offset) * Constants.SectorSize), SeekOrigin.Begin);
             long curPosition;
             while (size > data.Position - (initialOffset + (((long)offset) * Constants.SectorSize)))
             {

--- a/SabreTools.Wrappers/XboxISO.cs
+++ b/SabreTools.Wrappers/XboxISO.cs
@@ -101,10 +101,10 @@ namespace SabreTools.Wrappers
                 // Determine location/size of game partition based on total ISO size
                 model.XGDType = redumpType switch
                 {
-                    0 => 0, // XGD1
-                    1 or 2 or 3 or 4 => 1, // XGD2
-                    5 => 2, // XGD2 (Hybrid)
-                    6 or 7 => 3, // XGD3
+                    0 or 1 => 0, // XGD1
+                    2 or 3 or 4 or 5 => 1, // XGD2
+                    6 => 2, // XGD2 (Hybrid)
+                    7 or 8 => 3, // XGD3
                     _ => -1,
                 };
 


### PR DESCRIPTION
Add peek bytes to XDVDFS reading, before validation
Seek outside of ParseDirectoryDescriptor for better encapsulation.
Support `Test Equipment Boot Loader Utility (USA)` Xbox disc that has a unique ISO size compared to all other pressed Original Xbox discs.