### PR TITLE
Fix XDVDFS bug

### DIFF
--- a/SabreTools.Serialization.Readers/XDVDFS.cs
+++ b/SabreTools.Serialization.Readers/XDVDFS.cs
@@ -165,13 +165,6 @@ namespace SabreTools.Serialization.Readers
                     if (obj.ContainsKey(dr.ExtentOffset))
                         continue;
 
-                    // Ensure offset is valid
-                    if ((((long)dr.ExtentOffset) * Constants.SectorSize) + size > data.Length)
-                        return null;
-
-                    // Seek to child descriptor
-                    data.SeekIfPossible(initialOffset + (((long)dr.ExtentOffset) * Constants.SectorSize), SeekOrigin.Begin);
-
                     // Get all descriptors from child
                     var descriptors = ParseDirectoryDescriptors(data, initialOffset, dr.ExtentOffset, dr.ExtentSize);
                     if (descriptors is null)

--- a/SabreTools.Serialization.Readers/XDVDFS.cs
+++ b/SabreTools.Serialization.Readers/XDVDFS.cs
@@ -146,6 +146,10 @@ namespace SabreTools.Serialization.Readers
 
             var obj = new Dictionary<uint, DirectoryDescriptor>();
 
+            // Seek to current descriptor
+            data.SeekIfPossible(initialOffset + (((long)offset) * Constants.SectorSize), SeekOrigin.Begin);
+
+            // Parse current descriptor
             var dd = ParseDirectoryDescriptor(data, initialOffset, offset, size);
             if (dd is null)
                 return null;


### PR DESCRIPTION
Fixed bug in XDVDFS reading introduced by earlier PR that shifted the seek out of the ParseDirectoryDescriptor function but didn't re-add it to the correct location.