### PR TITLE
Ensure that the data being read is actually large enough to have a debug directory entry parsed from it

### DIFF
--- a/SabreTools.Serialization.Readers/PortableExecutable.cs
+++ b/SabreTools.Serialization.Readers/PortableExecutable.cs
@@ -749,7 +749,7 @@ namespace SabreTools.Serialization.Readers
             var table = new List<Data.Models.PortableExecutable.DebugData.Entry>();
 
             int offset = 0;
-            while (offset < data.Length)
+            while (offset < data.Length && data.Length - offset >= 28)
             {
                 var entry = ParseDebugDirectoryEntry(data, ref offset);
                 table.Add(entry);


### PR DESCRIPTION
For PE, no checks on the data size were performed to make sure that a debug directory entry could actually be parsed from the debug table, causing PE parsing to fail on some executables. In this specific case, the optionalheader has a debug table size of 1 byte, smaller than the 28 bytes needed to actually parse a debug directory entry.

Executable in question that this was failing on beforehand: 
[shuttle.zip](https://github.com/user-attachments/files/30529476/shuttle.zip)

Comes from Space Shuttle Mission Simulator (not on redump yet)